### PR TITLE
Fix the behaviour of the ROOT NamedKey of a hive

### DIFF
--- a/tests/test_regf.py
+++ b/tests/test_regf.py
@@ -5,10 +5,17 @@ def test_regf(system_hive):
     hive = regf.RegistryHive(system_hive)
 
     root = hive.root()
+
     assert len(list(root.subkeys())) == 17
+    assert root.name == "ROOT"
+    assert root.path == ""
     assert hive.open("Software") is root.subkey("Software") is root.subkey("software")
 
-    lsa = hive.open("ControlSet001\\Control\\LSA")
+    key_path = "ControlSet001\\Control\\Lsa"
+    lsa = hive.open(key_path)
+
+    assert lsa.name == "Lsa"
+    assert lsa.path == key_path
     assert lsa.subkey("JD").class_name == "cdebfed5"
     assert lsa.subkey("Skew1").class_name == "7db4e11c"
     assert lsa.subkey("GBG").class_name == "b185f3f2"


### PR DESCRIPTION
The ROOT NamedKey of a hive should not have a named part in the path. This will interfere when constructing a full path for a key when the hive is mapped on some subkey of another hive.

NamedKey.path() for the ROOT key failed as it did not take into consideration that it did not have any parents.