### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/regf/regf.py
+++ b/dissect/regf/regf.py
@@ -38,8 +38,6 @@ class RegistryHive:
     def __init__(self, fh):
         self.fh = fh
 
-        self.cell = lru_cache(4096)(self.cell)
-
         data = fh.read(4096)
         self.header = c_regf.REGF_HEADER(data)
         self.filename = self.header.filename.decode("utf-16-le").rstrip("\x00")
@@ -62,6 +60,9 @@ class RegistryHive:
             log.debug(f"Hive {self.filename!r} is not undergoing any transactions.")
 
         self.hbin_offset = 4096
+
+        self.cell = lru_cache(4096)(self.cell)
+
         self._root = self.cell(self.header.root_key_offset)
 
     def root(self):


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)