### PR TITLE
Fix iterating an IndexRoot

### DIFF
--- a/dissect/regf/regf.py
+++ b/dissect/regf/regf.py
@@ -351,7 +351,7 @@ class IndexRoot(KeyIndex):
 
     def __iter__(self) -> Iterator[KeyNode]:
         for entry in self.cell.List:
-            yield self.hive.cell(entry)
+            yield from self.hive.cell(entry)
 
     @cached_property
     def count(self) -> int:


### PR DESCRIPTION
When iterating an `IndexRoot`, the child cells will be some kind of leaf, so we need to `yield from` instead of `yield` the cells from the `IndexRoot` itself so that we actually end up yielding the `KeyNode`.

Unfortunately the test data doesn't have an `IndexRoot` so it's a bit tricky to create a unit test.

This was unfortunately overseen in the refactor as the old code does this properly: https://github.com/fox-it/dissect.regf/blob/6681506c51e4da73e4e82249c69295a661e1b43e/dissect/regf/regf.py#L342